### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,15 @@ RUN mkdir $(basename /usr/local/lib/python3.*/) && cd ./python3.*/ && \
 COPY ./boot.py /release/bin/syncplay
 
 FROM ${PYTHON}
+ARG USER_UID=800
+ARG USER_GID=800
 RUN sh -c '[ $(getconf LONG_BIT) -eq 64 ] || apk add --no-cache libgcc'
 COPY --from=syncplay /release/ /usr/
 ENV PYTHONUNBUFFERED=1
 EXPOSE 8999
 WORKDIR /data/
+RUN addgroup -g "${USER_GID}" -S syncplay && \
+    adduser -u "${USER_UID}" -S syncplay -G syncplay && \
+    chown -R syncplay:syncplay /data
+USER syncplay
 ENTRYPOINT ["syncplay"]


### PR DESCRIPTION
I really like your Dockerfiles, it solves the issues I had with other/older Dockerfiles for syncplay, where I couldn't motivate myself into doing what you did here. Thank you!

There is only suggestion I want to make for improvement: Run the service as a non-privileged user. This would improve isolation in case there is a security vulnerability in syncplay.

In this PR, this behaviour is optional and disabled by default. You need to specify `--build-arg RUNAS=user` in the build command line in order to run the daemon as a non-root user.
Downside to this: contents of the `/data` dir must belong to that chosen user, or syncplay won't be able to access them anymore. So migrating needs manual intervention. 
Same applies to TLS certs, they need to be readable by the chosen user (or a suitable user with sufficient permissions must be chosen).